### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,11 +14,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - "3.7"
         - "3.8"
         - "3.9"
         - "3.10"
         - "3.11"
+        - "3.12"
 
     steps:
       - uses: actions/checkout@v3
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,11 +16,11 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Framework :: Django
     Framework :: Django :: 3
     Framework :: Django :: 3.2
@@ -28,15 +28,17 @@ classifiers =
     Framework :: Django :: 4.0
     Framework :: Django :: 4.1
     Framework :: Django :: 4.2
+    Framework :: Django :: 5.0
+    Framework :: Django :: 5.1
 
 [options]
 packages = find:
 include_package_data = True
 install_requires =
     Django>=3.2
-    kafka-python>=2.0.2
+    kafka-python-ng>=2.2.2
     celery>=5.1.0
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.extras_require]
 tests =

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,12 @@
 [tox]
 envlist =
-    py{37,38,39,310}-dj32
+    py{38,39,310}-dj32
     py{38,39,310}-dj40
     py{38,39,310,311}-dj41
     py{310,311}-dj42
-    py311-djmain
+    py{311,312}-dj50
+    py{311,312}-dj51
+    py312-djmain
     qa
 
 [testenv]
@@ -16,7 +18,9 @@ deps =
     py37-dj32: importlib-metadata<5.0
     dj40: Django>=4.0,<4.1
     dj41: Django>=4.1.2,<4.2
-    dj42: Django>=4.2.1,<4.3
+    dj42: Django>=4.2.1,<5.0
+    dj50: Django>=5.0.0,<5.1
+    dj51: Django>=5.1.0,<5.2
     djmain: https://github.com/django/django/archive/main.tar.gz
 passenv =
     KAFKA_BOOTSTRAP_SERVERS


### PR DESCRIPTION
Replace kafka-python with kafka-python-ng. Remove support for Python 3.7. Add support for Python 3.12, Django 5.0 and 5.1